### PR TITLE
Fix mastercard number issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The custom fields configuration option allows you to specify any custom fields y
 The test cards are not listed in the documentation and they may change in future. Here are the current mastercard and visa test card numbers:
 
 **VISA**: 4124939999999990
-**MASTERCARD**: 5406004444444443
 
 ```
 

--- a/lib/elavon/transaction/http.ex
+++ b/lib/elavon/transaction/http.ex
@@ -11,7 +11,7 @@ defmodule Elavon.Transaction.HTTP do
   @opts [timeout: 30_000, recv_timeout: 30_000]
 
   def sale(params, opts \\ []) do
-    unwrap post("/process.do", params, [], opts ++ @opts)
+    unwrap post("/process.do", params, [], Keyword.merge(@opts, opts))
   end
 
   # HTTPoison Callbacks
@@ -41,7 +41,8 @@ defmodule Elavon.Transaction.HTTP do
       "ssl_pin" => Application.get_env(:elavon, :ssl_pin),
       "ssl_transaction_type" => "CCSALE",
       "ssl_result_format" => "ASCII",
-      "ssl_show_form" => "false"
+      "ssl_show_form" => "false",
+      "ssl_txn_currency_code" => "USD"
     }
 
     base_params
@@ -68,7 +69,7 @@ defmodule Elavon.Transaction.HTTP do
     |> String.split("\n")
     |> Enum.filter(&String.contains?(&1, "="))
     |> Enum.map(fn line ->
-        [key, value | _tail] = String.split(line, "=")
+        [key, value] = String.split(line, "=", parts: 2)
         key = String.trim(key) |> String.to_atom
         value = if String.trim(value) == "", do: nil, else: String.trim(value)
         {key, value}

--- a/test/elavon_test.exs
+++ b/test/elavon_test.exs
@@ -2,7 +2,7 @@ defmodule ElavonTest do
   use ExUnit.Case
 
   @visa 4124939999999990
-  @mastercard 5406004444444443
+  @invalid_mastercard 5406004444444443
   @invalid 0000000000000000
 
   describe ".sale" do
@@ -28,6 +28,20 @@ defmodule ElavonTest do
       assert t.ssl_txn_time
     end
 
+    test "handles invalid master card currency error" do
+      params = %{
+        ssl_card_number: @invalid_mastercard,
+        ssl_cvv2cvc2_indicator: 1,
+        ssl_cvv2cvc2: 123,
+        ssl_amount: 10.00,
+        ssl_exp_date: 1220,
+        ssl_invoice_number: to_string(Enum.take_random(?a..?z, 20))
+      }
+
+      {:error, %Elavon.Exception{} = e} = Elavon.sale(params)
+      assert e.raw_body[:dccoption] =~ "Please charge my purchase in my home currency"
+    end
+
     test "handles invalid card error" do
       params = %{
         ssl_card_number: @invalid,
@@ -47,7 +61,7 @@ defmodule ElavonTest do
 
     test "handles invalid cvv" do
       params = %{
-        ssl_card_number: @mastercard,
+        ssl_card_number: @invalid_mastercard,
         ssl_cvv2cvc2_indicator: 1,
         ssl_cvv2cvc2: 6,
         ssl_amount: 10.00,


### PR DESCRIPTION
The mastercard number given to me by Elavon for testing only accepts euro payments, so it fails when charging US dollars against it.

I updated the Readme & added a test to ensure we parsed this type of error properly.